### PR TITLE
Set pageUrl in tracking cookie to the current page

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -206,7 +206,7 @@ class Base extends \GFFeedAddOn {
         $hs_context     = array(
             'hutk'      => $hubspotutk,
             'ipAddress' => $ip_addr,
-            'pageUrl'   => apply_filters( 'gf_hubspot_context_url', site_url() ),
+            'pageUrl'   => apply_filters( 'gf_hubspot_context_url', site_url(strtok($_SERVER['REQUEST_URI'])) ),
             'pageName'  => apply_filters( 'gf_hubspot_context_name', $this->getValue($form, 'title') ),
         );
         if ( $this->getValue($feed, 'meta/disableCookie') == 1 ) {


### PR DESCRIPTION
In HubSpot, the tracking cookie should be updated with the `pageUrl` reflecting the actual page that the form is on and being submitted on.

This has caused issues on HubSpot contact records, since the contact record shows

`Contact Name` submitted `HubSpot Form Name` on `Gravity Forms Name`

`Gravity Forms Name` currently links to the `pageUrl` value set in the tracking cookie (which is currently just the site's homepage, while the `pageName` is set to the name of the form (typically representative of the page the form is on).

So to help make things more clear, `pageUrl` should be set to whatever URL the user is on when they submit the form, since that's much more representative than just the homepage.