### PR TITLE
Send Page Title to HubSpot instead of Form Title

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -207,7 +207,7 @@ class Base extends \GFFeedAddOn {
             'hutk'      => $hubspotutk,
             'ipAddress' => $ip_addr,
             'pageUrl'   => apply_filters( 'gf_hubspot_context_url', site_url(strtok($_SERVER['REQUEST_URI'], '?')) ),
-            'pageName'  => apply_filters( 'gf_hubspot_context_name', $this->getValue($form, 'title') ),
+            'pageName'  => apply_filters( 'gf_hubspot_context_name', get_the_title() ),
         );
         if ( $this->getValue($feed, 'meta/disableCookie') == 1 ) {
             unset($hs_context['hutk']);


### PR DESCRIPTION
Since the form is linked to HubSpot already, the notifications sent from HubSpot already explain what form was filled out. So sending the GravityForms form title doesn't make much sense/explain more.

It makes more sense to get the current page title that's submitting the form, so that way when the notification gets sent from HubSpot, it accurately shows what page the person submitted the form on.